### PR TITLE
Add -ExcludeVersion to the nuget install step

### DIFF
--- a/poshstack_getting_started_guide.md
+++ b/poshstack_getting_started_guide.md
@@ -57,12 +57,9 @@ CD C:\Users\Administrator\Documents\WindowsPowerShell\Modules
 and install PoshStack:
 
 ```dos
-Nuget install PoshStack
+Nuget install PoshStack -ExcludeVersion
 ```
-### Rename the resulting folder
-```dos
-Rename PoshStack.0.0.1 PoshStack
-```
+
 
 
 ## 3. PoshStack Configuration


### PR DESCRIPTION
This removes the need to have an additional step just for renaming the folder when installing via nuget.